### PR TITLE
Fixed delete to retain identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # People Reader/Writer for Neo4j (people-rw-neo4j)
 
+[![Circle CI](https://circleci.com/gh/Financial-Times/people-rw-neo4j.svg?style=shield)](https://circleci.com/gh/Financial-Times/people-rw-neo4j)[![Go Report Card](https://goreportcard.com/badge/github.com/Financial-Times/people-rw-neo4j)](https://goreportcard.com/report/github.com/Financial-Times/people-rw-neo4j) [![Coverage Status](https://coveralls.io/repos/github/Financial-Times/people-rw-neo4j/badge.svg)](https://coveralls.io/github/Financial-Times/people-rw-neo4j)
+
 __An API for reading/writing people into Neo4j. Expects the people json supplied to be in the format that comes out of the people transformer.__
 
 ## Installation

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,22 @@ machine:
     - neo4j
   environment:
     NEO4J_TEST_URL: http://neo4j:x@localhost:7474/db/data/
+    _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
 
+dependencies:
+  pre:
+    - go get github.com/axw/gocov/gocov; go get github.com/matm/gocov-html; go get -u github.com/jstemmer/go-junit-report
 test:
   pre:
+    - go get github.com/mattn/goveralls
     - 'curl -u neo4j:neo4j -H "Content-Type: application/json" -X POST -d ''{"password":"x"}''  http://localhost:7474/user/neo4j/password'
+  override:
+    - mkdir -p $CIRCLE_TEST_REPORTS/golang
+    - go test -race -v ./... | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
+    - go list ./... | awk -F/ '{print $4}' | xargs -I {} go test -v -cover -race -coverprofile=$CIRCLE_ARTIFACTS/{}.out ./{}
+    - cd $CIRCLE_ARTIFACTS && sed -i '1d' *.out
+    - |
+      echo "mode: atomic" > $CIRCLE_ARTIFACTS/overall-coverage.result
+    - cd $CIRCLE_ARTIFACTS && cat *.out >> overall-coverage.result
+  post:
+    - goveralls -coverprofile=$CIRCLE_ARTIFACTS/overall-coverage.result -service=circle-ci -repotoken=$COVERALLS_TOKEN

--- a/people/fixtures/Annotations-3fc9fe3e-af8c-4f7f-961a-e5065392bb31-v2.json
+++ b/people/fixtures/Annotations-3fc9fe3e-af8c-4f7f-961a-e5065392bb31-v2.json
@@ -1,0 +1,27 @@
+[
+  {
+    "thing": {
+      "id": "http://api.ft.com/things/bbc4f575-edb3-4f51-92f0-5ce6c708d1ea",
+      "prefLabel": "Pref Label",
+      "types": [
+          "http://www.ft.com/ontology/person/Person"
+      ]
+    },
+    "provenances": [
+      {
+        "scores": [
+          {
+            "scoringSystem": "http://api.ft.com/scoringsystem/FT-RELEVANCE-SYSTEM",
+            "value": 0.9
+          },
+          {
+            "scoringSystem": "http://api.ft.com/scoringsystem/FT-CONFIDENCE-SYSTEM",
+            "value": 0.76
+          }
+        ],
+        "atTime": "2016-01-20T19:43:47.314Z",
+        "agentRole": "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a"
+      }
+    ]
+  }
+]

--- a/people/fixtures/Content-3fc9fe3e-af8c-4f7f-961a-e5065392bb31.json
+++ b/people/fixtures/Content-3fc9fe3e-af8c-4f7f-961a-e5065392bb31.json
@@ -1,0 +1,13 @@
+{
+  "uuid": "3fc9fe3e-af8c-4f7f-961a-e5065392bb31",
+  "title": "Bitcoin story makes Newsweek the headline",
+  "byline": "By Matthew Garrahan in Los Angeles",
+  "identifiers": [
+    {
+      "authority": "http://api.ft.com/system/FTCOM-METHODE",
+      "identifierValue": "3fc9fe3e-af8c-4f7f-961a-e5065392bb31"
+    }
+  ],
+  "publishedDate": "2014-03-07T19:18:01.000Z",
+  "body": "<body><ft-content type=\"http://www.ft.com/ontology/content/ImageSet\" url=\"http://test.api.ft.com/content/666f7190-a5d4-11e3-278b-978e959e1c97\" data-embedded=\"true\"></ft-content><p>On paper, it looked like the story of the year. Newsweek, it appeared, had identified the founder of <a href=\"http://www.ft.com/intl/indepth/bitcoin\" title=\"Bitcoin in depth - FT.com\">Bitcoin</a>. </p>\n</body>"
+}

--- a/people/people_service.go
+++ b/people/people_service.go
@@ -197,9 +197,8 @@ func (s service) Write(thing interface{}) error {
 	}
 
 	deleteEntityRelationshipsQuery := &neoism.CypherQuery{
-		Statement: `MATCH (t:Thing {uuid:{uuid}})
-					OPTIONAL MATCH (i:Identifier)-[ir:IDENTIFIES]->(t)
-					DELETE ir, i`,
+		Statement: `MATCH (i:Identifier)-[ir:IDENTIFIES]->(t:Thing {uuid:{uuid}})
+				DELETE ir, i`,
 		Parameters: map[string]interface{}{
 			"uuid": p.UUID,
 		},

--- a/people/people_service.go
+++ b/people/people_service.go
@@ -270,7 +270,8 @@ func (s service) Delete(uuid string) (bool, error) {
 		IncludeStats: true,
 	}
 
-	// Please note that this keeps the Identifiers as Identifiers are NOT a Thing
+	// Please note that this removes the Identifiers if there are no other relationships attached to this
+	// as Identifiers are not a 'Thing' only an Identifier
 	removeNodeIfUnused := &neoism.CypherQuery{
 		Statement: `
 			MATCH (thing:Thing {uuid: {uuid}})

--- a/people/people_service.go
+++ b/people/people_service.go
@@ -239,8 +239,7 @@ func (s service) Write(thing interface{}) error {
 
 func createNewIdentifierQuery(uuid string, identifierLabel string, identifierValue string) *neoism.CypherQuery {
 	statementTemplate := fmt.Sprintf(`MERGE (t:Thing {uuid:{uuid}})
-					CREATE (i:Identifier {value:{value}})
-					MERGE (t)<-[:IDENTIFIES]-(i)
+					CREATE (i:Identifier {value:{value}})-[:IDENTIFIES]->(t)
 					set i : %s `, identifierLabel)
 	query := &neoism.CypherQuery{
 		Statement: statementTemplate,

--- a/people/people_service_test.go
+++ b/people/people_service_test.go
@@ -9,6 +9,10 @@ import (
 	"sync"
 	"testing"
 
+	"encoding/json"
+	"github.com/Financial-Times/annotations-rw-neo4j/annotations"
+	"github.com/Financial-Times/base-ft-rw-app-go/baseftrwapp"
+	"github.com/Financial-Times/content-rw-neo4j/content"
 	"github.com/Financial-Times/neo-utils-go/neoutils"
 	"github.com/Financial-Times/up-rw-app-api-go/rwapi"
 	"github.com/jmcvetta/neoism"
@@ -22,6 +26,7 @@ const (
 	fullPersonSecondUuid = "026bc6ab-3581-476f-bdee-ad44934d8255"
 	fullPersonThirdUuid  = "38431a92-dda3-4eb9-a367-60145a8e659f"
 	uniquePersonUuid     = "bb596d64-78c5-4b00-a88f-e8248c956073"
+	contentUUID          = "3fc9fe3e-af8c-4f7f-961a-e5065392bb31"
 )
 
 var minimalPerson = person{
@@ -63,7 +68,8 @@ func TestCreateAllValuesPresent(t *testing.T) {
 
 	db := getDatabaseConnectionAndCheckClean(t, assert)
 	peopleDriver := getCypherDriver(db)
-	defer cleanDB(db, t, assert)
+
+	defer cleanDB([]string{fullPersonUuid}, db, t, assert)
 
 	assert.NoError(peopleDriver.Write(fullPerson), "Failed to write person")
 
@@ -74,7 +80,8 @@ func TestCreateNotAllValuesPresent(t *testing.T) {
 	assert := assert.New(t)
 	db := getDatabaseConnectionAndCheckClean(t, assert)
 	peopleDriver := getCypherDriver(db)
-	defer cleanDB(db, t, assert)
+
+	defer cleanDB([]string{minimalPersonUuid}, db, t, assert)
 
 	assert.NoError(peopleDriver.Write(minimalPerson), "Failed to write person")
 
@@ -85,7 +92,8 @@ func TestCreateHandlesSpecialCharacters(t *testing.T) {
 	assert := assert.New(t)
 	db := getDatabaseConnectionAndCheckClean(t, assert)
 	peopleDriver := getCypherDriver(db)
-	defer cleanDB(db, t, assert)
+
+	defer cleanDB([]string{uniquePersonUuid}, db, t, assert)
 
 	personToWrite := person{UUID: uniquePersonUuid, Name: "Thomas M. O'Gara", BirthYear: 1974, Salutation: "Mr", AlternativeIdentifiers: alternativeIdentifiers{FactsetIdentifier: "FACTSET_ID", UUIDS: []string{uniquePersonUuid}, TME: []string{}}, Aliases: []string{"alias 1", "alias 2"}, Types: defaultTypes}
 
@@ -98,7 +106,8 @@ func TestUpdateWillRemovePropertiesNoLongerPresent(t *testing.T) {
 	assert := assert.New(t)
 	db := getDatabaseConnectionAndCheckClean(t, assert)
 	peopleDriver := getCypherDriver(db)
-	defer cleanDB(db, t, assert)
+
+	defer cleanDB([]string{fullPersonUuid}, db, t, assert)
 
 	assert.NoError(peopleDriver.Write(fullPerson), "Failed to write person")
 	storedFullPerson, _, err := peopleDriver.Read(fullPersonUuid)
@@ -122,7 +131,8 @@ func TestAliasesAreWrittenAndAreAbleToBeReadInOrder(t *testing.T) {
 	assert := assert.New(t)
 	db := getDatabaseConnectionAndCheckClean(t, assert)
 	peopleDriver := getCypherDriver(db)
-	defer cleanDB(db, t, assert)
+
+	defer cleanDB([]string{uniquePersonUuid}, db, t, assert)
 	personToWrite := person{UUID: uniquePersonUuid, Name: "Test", BirthYear: 1974, Salutation: "Mr", AlternativeIdentifiers: alternativeIdentifiers{FactsetIdentifier: "FACTSET_ID", UUIDS: []string{uniquePersonUuid}}, Aliases: []string{"alias 1", "alias 2"}}
 
 	peopleDriver.Write(personToWrite)
@@ -151,7 +161,9 @@ func TestAddingPersonWithExistingIdentifiersShouldFail(t *testing.T) {
 
 	db := getDatabaseConnectionAndCheckClean(t, assert)
 	cypherDriver := getCypherDriver(db)
-	defer cleanDB(db, t, assert)
+
+	defer cleanDB([]string{minimalPersonUuid, fullPersonUuid}, db, t, assert)
+
 	assert.NoError(cypherDriver.Write(fullPerson))
 	err := cypherDriver.Write(minimalPerson)
 	assert.Error(err)
@@ -162,7 +174,8 @@ func TestPrefLabelIsEqualToPrefLabelAndAbleToBeRead(t *testing.T) {
 	assert := assert.New(t)
 	db := getDatabaseConnectionAndCheckClean(t, assert)
 	peopleDriver := getCypherDriver(db)
-	defer cleanDB(db, t, assert)
+
+	defer cleanDB([]string{fullPersonUuid}, db, t, assert)
 
 	storedPerson := peopleDriver.Write(fullPerson)
 
@@ -187,11 +200,12 @@ func TestPrefLabelIsEqualToPrefLabelAndAbleToBeRead(t *testing.T) {
 	assert.Equal(fullPerson.PrefLabel, result[0].PrefLabel, "PrefLabel should be 'Pref Label")
 }
 
-func TestDelete(t *testing.T) {
+func TestDeleteWillDeleteEntireNodeIfNoRelationship(t *testing.T) {
 	assert := assert.New(t)
 	db := getDatabaseConnectionAndCheckClean(t, assert)
 	peopleDriver := getCypherDriver(db)
-	defer cleanDB(db, t, assert)
+
+	defer cleanDB([]string{minimalPersonUuid}, db, t, assert)
 
 	assert.NoError(peopleDriver.Write(minimalPerson), "Failed to write person")
 
@@ -204,6 +218,31 @@ func TestDelete(t *testing.T) {
 	assert.Equal(person{}, p, "Found person %s who should have been deleted", p)
 	assert.False(found, "Found person for uuid %s who should have been deleted", minimalPersonUuid)
 	assert.NoError(err, "Error trying to find person for uuid %s", minimalPersonUuid)
+	assert.Equal(false, doesThingExistAtAll(minimalPersonUuid, db, t, assert), "Found thing who should have been deleted uuid: %s", minimalPersonUuid)
+}
+
+func TestDeleteWithRelationshipsMaintainsRelationships(t *testing.T) {
+	assert := assert.New(t)
+	db := getDatabaseConnectionAndCheckClean(t, assert)
+	peopleDriver := getCypherDriver(db)
+
+	defer cleanDB([]string{fullPersonUuid, contentUUID}, db, t, assert)
+
+	assert.NoError(peopleDriver.Write(fullPerson), "Failed to write person")
+	writeContent(assert, db)
+	writeAnnotation(assert, db)
+
+	found, err := peopleDriver.Delete(fullPersonUuid)
+
+	assert.True(found, "Didn't manage to delete person for uuid %", fullPersonUuid)
+	assert.NoError(err, "Error deleting person for uuid %s", fullPersonUuid)
+
+	p, found, err := peopleDriver.Read(fullPersonUuid)
+
+	assert.Equal(person{}, p, "Found person %s who should have been deleted", p)
+	assert.False(found, "Found person for uuid %s who should have been deleted", fullPersonUuid)
+	assert.NoError(err, "Error trying to find person for uuid %s", fullPersonUuid)
+	assert.Equal(true, doesThingExistWithIdentifiers(fullPersonUuid, db, t, assert), "Unable to find a Thing with any Identifiers, uuid: %s", fullPersonUuid)
 }
 
 func TestIDs(t *testing.T) {
@@ -272,6 +311,40 @@ func TestIDs(t *testing.T) {
 
 }
 
+func writeAnnotation(assert *assert.Assertions, db neoutils.NeoConnection) annotations.Service {
+	annotationsRW := annotations.NewCypherAnnotationsService(db, "v2")
+	assert.NoError(annotationsRW.Initialise())
+	writeJSONToAnnotationsService(annotationsRW, contentUUID, "./fixtures/Annotations-3fc9fe3e-af8c-4f7f-961a-e5065392bb31-v2.json", assert)
+	return annotationsRW
+}
+
+func writeContent(assert *assert.Assertions, db neoutils.NeoConnection) baseftrwapp.Service {
+	contentRW := content.NewCypherContentService(db)
+	assert.NoError(contentRW.Initialise())
+	writeJSONToService(contentRW, "./fixtures/Content-3fc9fe3e-af8c-4f7f-961a-e5065392bb31.json", assert)
+	return contentRW
+}
+
+func writeJSONToAnnotationsService(service annotations.Service, contentUUID string, pathToJSONFile string, assert *assert.Assertions) {
+	f, err := os.Open(pathToJSONFile)
+	assert.NoError(err)
+	dec := json.NewDecoder(f)
+	inst, errr := service.DecodeJSON(dec)
+	assert.NoError(errr, "Error parsing file %s", pathToJSONFile)
+	errrr := service.Write(contentUUID, inst)
+	assert.NoError(errrr)
+}
+
+func writeJSONToService(service baseftrwapp.Service, pathToJSONFile string, assert *assert.Assertions) {
+	f, err := os.Open(pathToJSONFile)
+	assert.NoError(err)
+	dec := json.NewDecoder(f)
+	inst, _, errr := service.DecodeJSON(dec)
+	assert.NoError(errr)
+	errrr := service.Write(inst)
+	assert.NoError(errrr)
+}
+
 func readPeopleAndCompare(expected person, t *testing.T, db neoutils.NeoConnection) {
 	sort.Strings(expected.Types)
 	sort.Strings(expected.AlternativeIdentifiers.TME)
@@ -291,8 +364,7 @@ func readPeopleAndCompare(expected person, t *testing.T, db neoutils.NeoConnecti
 
 func getDatabaseConnectionAndCheckClean(t *testing.T, assert *assert.Assertions) neoutils.NeoConnection {
 	db := getDatabaseConnection(assert)
-	cleanDB(db, t, assert)
-	checkDbClean(db, t)
+	checkDbClean([]string{fullPersonUuid, contentUUID, minimalPersonUuid, fullPersonSecondUuid, fullPersonThirdUuid, uniquePersonUuid}, db, t)
 	return db
 }
 
@@ -309,36 +381,89 @@ func getDatabaseConnection(assert *assert.Assertions) neoutils.NeoConnection {
 	return db
 }
 
-func cleanDB(db neoutils.NeoConnection, t *testing.T, assert *assert.Assertions) {
-	qs := []*neoism.CypherQuery{
-		{
-			Statement: fmt.Sprintf("MATCH (mp:Thing {uuid: '%v'})<-[:IDENTIFIES*0..]-(i:Identifier) DETACH DELETE mp, i", minimalPersonUuid),
-		},
-		{
-			Statement: fmt.Sprintf("MATCH (fp:Thing {uuid: '%v'})<-[:IDENTIFIES*0..]-(i:Identifier) DETACH DELETE fp, i", fullPersonUuid),
-		},
-		{
-			Statement: fmt.Sprintf("MATCH (fp:Thing {uuid: '%v'})<-[:IDENTIFIES*0..]-(i:Identifier) DETACH DELETE fp, i", uniquePersonUuid),
-		},
+func cleanDB(uuidsToClean []string, db neoutils.NeoConnection, t *testing.T, assert *assert.Assertions) {
+	qs := make([]*neoism.CypherQuery, len(uuidsToClean))
+	for i, uuid := range uuidsToClean {
+		qs[i] = &neoism.CypherQuery{
+			Statement: fmt.Sprintf(`
+			MATCH (a:Thing {uuid: "%s"})
+			OPTIONAL MATCH (a)-[rel]-(i)
+			DELETE rel, i
+			DETACH DELETE a`, uuid)}
 	}
-
 	err := db.CypherBatch(qs)
 	assert.NoError(err)
 }
 
-func checkDbClean(db neoutils.NeoConnection, t *testing.T) {
-	assert := assert.New(t)
-
+func doesThingExistAtAll(uuid string, db neoutils.NeoConnection, t *testing.T, assert *assert.Assertions) bool {
 	result := []struct {
-		Uuid string `json:"org.uuid"`
+		Uuid string `json:"thing.uuid"`
 	}{}
 
 	checkGraph := neoism.CypherQuery{
 		Statement: `
-			MATCH (org:Thing) WHERE org.uuid in {uuids} RETURN org.uuid
+			MATCH (a:Thing {uuid: "%s"}) return a.uuid
 		`,
 		Parameters: neoism.Props{
-			"uuids": []string{fullPersonUuid, minimalPersonUuid, uniquePersonUuid},
+			"uuid": uuid,
+		},
+		Result: &result,
+	}
+
+	err := db.CypherBatch([]*neoism.CypherQuery{&checkGraph})
+	assert.NoError(err)
+
+	if len(result) == 0 {
+		return false
+	}
+
+	return true
+}
+
+func doesThingExistWithIdentifiers(uuid string, db neoutils.NeoConnection, t *testing.T, assert *assert.Assertions) bool {
+
+	result := []struct {
+		uuid string `json:"thing.uuid"`
+	}{}
+
+	checkGraph := neoism.CypherQuery{
+		Statement: `
+			MATCH (a:Thing {uuid: "%s"})-[:IDENTIFIES]-(:Identifier)
+			WITH collect(distinct a.uuid) as uuid
+			RETURN uuid
+		`,
+		Parameters: neoism.Props{
+			"uuid": uuid,
+		},
+		Result: &result,
+	}
+
+	fmt.Printf("Result: %v", len(result))
+	err := db.CypherBatch([]*neoism.CypherQuery{&checkGraph})
+	assert.NoError(err)
+	fmt.Printf("Result2: %v", result)
+
+	if len(result) == 0 {
+		return false
+	}
+
+	fmt.Printf("Result3: %v", len(result))
+	return true
+}
+
+func checkDbClean(uuidsCleaned []string, db neoutils.NeoConnection, t *testing.T) {
+	assert := assert.New(t)
+
+	result := []struct {
+		Uuid string `json:"thing.uuid"`
+	}{}
+
+	checkGraph := neoism.CypherQuery{
+		Statement: `
+			MATCH (thing) WHERE thing.uuid in {uuids} RETURN thing.uuid
+		`,
+		Parameters: neoism.Props{
+			"uuids": uuidsCleaned,
 		},
 		Result: &result,
 	}


### PR DESCRIPTION
When we introduced the Identifier nodes we failed to also update the delete to cope with the mechanism.
We should be deleting all the nodes and the identifiers if there are no other relationships to other Things otherwise we remove all properties but retain the identifiers